### PR TITLE
const for == and != operators overload

### DIFF
--- a/RapidXML/rapidxml_iterators.hpp
+++ b/RapidXML/rapidxml_iterators.hpp
@@ -74,12 +74,12 @@ namespace rapidxml
             return tmp;
         }
 
-        bool operator ==(const node_iterator<Ch> &rhs)
+        bool operator ==(const node_iterator<Ch> &rhs) const
         {
             return m_node == rhs.m_node;
         }
 
-        bool operator !=(const node_iterator<Ch> &rhs)
+        bool operator !=(const node_iterator<Ch> &rhs) const
         {
             return m_node != rhs.m_node;
         }


### PR DESCRIPTION
This would fix the following warning: ISO C++20 considers use of overloaded operator '!=' (with operand types 'rapidxml::node_iterator<>' and 'rapidxml::node_iterator<>') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Wambiguous-reversed-operator]