### PR TITLE
When Parse flag is default, whitespace text should be retained

### DIFF
--- a/RapidXML/rapidxml.hpp
+++ b/RapidXML/rapidxml.hpp
@@ -2184,6 +2184,10 @@ namespace rapidxml
                 case Ch('<'):
                     if (text[1] == Ch('/'))
                     {
+                        // Text has only whitespace characters (clown, 2009/10/14, https://sourceforge.net/p/rapidxml/patches/4/).
+                        if (contents_start != text && !(Flags & parse_trim_whitespace))
+                            parse_and_append_data<Flags>(node, contents_start, contents_start);
+
                         // Node closing
                         text += 2;      // Skip '</'
                         if (Flags & parse_validate_closing_tags)
@@ -2212,6 +2216,10 @@ namespace rapidxml
                         ++text;     // Skip '<'
                         if (xml_node<Ch> *child = parse_node<Flags>(text))
                             node->append_node(child);
+
+                        // Skip whitespace between closing-tag of child node
+                        // and the next element (clown, 2009/10/14, https://sourceforge.net/p/rapidxml/patches/4/).
+                        skip<whitespace_pred, Flags>(text);
                     }
                     break;
 
@@ -2222,6 +2230,7 @@ namespace rapidxml
                 // Data node
                 default:
                     next_char = parse_and_append_data<Flags>(node, text, contents_start);
+                    contents_start = text; // (clown, 2009/10/16, https://sourceforge.net/p/rapidxml/patches/4/)
                     goto after_data_node;   // Bypass regular processing after data nodes
 
                 }


### PR DESCRIPTION
An issue was found while using the default parse flag, nodes with whitespace as the text are still trimmed. It is expected that unless the "parse_trim_whitespace" flag is used, whitespace should be retained. 

```
Example of the issue:
<Node> <Node> -> <Node><Node>
<Node>  <Node> -> <Node><Node>
<Node>   <Node> -> <Node><Node>
```

This change was found on sourceforge as a patch for the original project, and has been tested to ensure fix still is applicable. I kept attribution to user "clown" but made slight alteration to style in the if-statement to remain cohesive with the rest of the project.

https://sourceforge.net/p/rapidxml/patches/4/